### PR TITLE
Fix font size issue for auto-filled web browser fields

### DIFF
--- a/styles/input.css
+++ b/styles/input.css
@@ -1,0 +1,4 @@
+/* Added rule to ensure auto-filled input fields have consistent font size */
+input:-webkit-autofill {
+    font-size: 16px;
+}


### PR DESCRIPTION
This pull request addresses the issue where the font size is too small when the web browser automatically fills input form fields. The fix ensures the font size is consistent with the rest of the text fields.