### PR TITLE
Fix font size for auto-filled input fields

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,4 @@
+// CSS fix for auto-filled input font-size issue
+input:-webkit-autofill {
+    font-size: 16px;
+}


### PR DESCRIPTION
This PR addresses the bug where the font size of auto-filled input fields was too small. The issue is fixed by explicitly setting the font size in the CSS for auto-filled inputs.